### PR TITLE
restrict pod deployment to linux/ppc64le nodes

### DIFF
--- a/deployment/kubesentry-daemonset.yaml
+++ b/deployment/kubesentry-daemonset.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         app: kube-sentry
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: ppc64le
       containers:
         - name: kube-sentry
           image: ghcr.io/ppc64le-cloud/kube-sentry:v0.1


### PR DESCRIPTION
What this PR does / why we need it: The requirement is to ensure that in a Multi-arch cluster, the kube-sentry daemonset deploys pods only on linux/ppc64le nodes.