### PR TITLE
Add groups configuration for GitHub Actions packages

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,3 +22,7 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      gh-actions-packages:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group GHA related PRs as a single group.